### PR TITLE
use attribute as key in assets type

### DIFF
--- a/AssetsBundle/DependencyInjection/Configuration.php
+++ b/AssetsBundle/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
         // @formatter:off
         /** @noinspection PhpUndefinedMethodInspection */
         $node->arrayNode('types')
+                ->useAttributeAsKey('assets_type')
                 ->prototype('array')
                 ->addDefaultsIfNotSet()
                 ->children()

--- a/AssetsBundle/DependencyInjection/Configuration.php
+++ b/AssetsBundle/DependencyInjection/Configuration.php
@@ -35,7 +35,7 @@ class Configuration implements ConfigurationInterface
         // @formatter:off
         /** @noinspection PhpUndefinedMethodInspection */
         $node->arrayNode('types')
-                ->useAttributeAsKey('assets_type')
+                ->useAttributeAsKey('type')
                 ->prototype('array')
                 ->addDefaultsIfNotSet()
                 ->children()


### PR DESCRIPTION
Keys are ignored by proccess configuration if you divide config to separate files